### PR TITLE
add path scrubber

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-## IBM Cloud CLI Web Terminal
+# IBM Cloud CLI Web Terminal

--- a/scrub-dind.yaml
+++ b/scrub-dind.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pv-recycler
+  namespace: default
+spec:
+  restartPolicy: Never
+  volumes:
+  - name: vol
+    hostPath:
+      path: /tmp
+  containers:
+  - name: pv-recycler
+    image: "k8s.gcr.io/busybox"
+    command: ["/bin/sh", "-c", "test -e /scrub && rm -rf /scrub/dind* && test -z \"$(ls -A /scrub/dind*)\" || exit 1"]
+    volumeMounts:
+    - name: vol
+      mountPath: /scrub


### PR DESCRIPTION
Add yaml for simple pod that can recycle the IKS worker path to allow reuse of a cluster. Helm delete of the release and PV removal doesn't touch content from hostPaths.